### PR TITLE
Adding pident average to taxonomy file

### DIFF
--- a/eefinder/bed.py
+++ b/eefinder/bed.py
@@ -53,7 +53,11 @@ class GetAnnotBed:
             r"\:.*", "", regex=True
         )
         df_blast_tax_info["sseqid"] = (
-            df_blast_tax_info["sseqid"] + "|" + df_blast_tax_info["sense"]
+            df_blast_tax_info["sseqid"]
+            + "|"
+            + df_blast_tax_info["sense"]
+            + "|"
+            + df_blast_tax_info["pident"].astype(str)
         )
         df_blast_tax_info["Family"] = df_blast_tax_info["Family"].fillna("Unknown")
         df_blast_tax_info["Genus"] = df_blast_tax_info["Genus"].fillna("Unknown")

--- a/eefinder/bed.py
+++ b/eefinder/bed.py
@@ -55,8 +55,8 @@ class GetAnnotBed:
         df_blast_tax_info["sseqid"] = (
             df_blast_tax_info["sseqid"] + "|" + df_blast_tax_info["sense"]
         )
-        df_blast_tax_info["Family"].fillna("Unknown", inplace=True)
-        df_blast_tax_info["Genus"].fillna("Unknown", inplace=True)
+        df_blast_tax_info["Family"] = df_blast_tax_info["Family"].fillna("Unknown")
+        df_blast_tax_info["Genus"] = df_blast_tax_info["Genus"].fillna("Unknown")
 
         if self.merge_level == "genus":
             df_blast_tax_info["formated_name"] = np.where(

--- a/eefinder/filter_table.py
+++ b/eefinder/filter_table.py
@@ -59,6 +59,7 @@ class FilterTable:
         if os.path.exists(tmp_path) == False:
             os.mkdir(tmp_path)
         for df in chunks:
+            df["sense"] = df["sense"].astype(object)
             df.loc[
                 df["qstart"].astype(int) > df["qend"].values.astype(int), "sense"
             ] = "neg"

--- a/eefinder/filter_table.py
+++ b/eefinder/filter_table.py
@@ -81,26 +81,6 @@ class FilterTable:
                 df["bed_name"] = df["qseqid"]
             pd.options.display.float_format = "{:,.2f}".format
             df["evalue"] = pd.to_numeric(df["evalue"], downcast="float")
-            """
-            ##TODO: move to documentation
-            '''
-            The next three line is a trick used to remove redundant hits () in in 3 decimal places, in this case, as we are
-            using a blast do recovery the EE signature in queries, that represent our genome, the filter is applied by
-            query name and query start and end ranges, an example:
-            INPUT:
-            qseqid	sseqid	pident	length	mismatch	gapopen	qstart	qend	sstart	send	evalue	bitscore
-            aag2_ctg_162	AAC97621	30.636	173	108	3	130612	130100	132	294	2.43e-08	69.7
-            aag2_ctg_162	AAU10897	23.611	216	163	2	130717	130073	134	348	2.52e-10	75.3
-            aag2_ctg_162	AOC55195	24.535	269	197	4	130864	130073	84	351	4.49e-11	77.8
-            OUTPUT:
-            qseqid	sseqid	pident	length	mismatch	gapopen	qstart	qend	sstart	send	evalue	bitscore	sense
-            aag2_ctg_162	AOC55195	24.535	269	197	4	130073	130864	84	351	4.49e-11	77.8	-
-            '''
-            df['qstart_rng'] = df.qstart.floordiv(100)
-            df['qend_rng'] = df.qend.floordiv(100)
-            df = df.drop_duplicates(subset=['qseqid', 'qstart_rng', 'sense']).drop_duplicates(
-                            subset=['qseqid', 'qstart_rng', 'sense']).sort_values(by=['qseqid'])
-            """
             df = df[df.length >= 33]
             header = [
                 "qseqid",

--- a/eefinder/tag_elements.py
+++ b/eefinder/tag_elements.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 
 
 def _list_to_string(overlaped_elements: list) -> str:
@@ -16,6 +17,7 @@ class TagElements:
         self.tax_file = tax_file
 
         self.tag_elements()
+        self.get_average_pident()
 
     def tag_elements(self) -> None:
         df = pd.read_csv(self.tax_file, sep="\t")
@@ -52,4 +54,13 @@ class TagElements:
                 row["Overlaped_Element_ID"] != ""
                 df.at[i, "tag"] = "overlaped"
 
+        df.to_csv(self.tax_file, sep="\t", index=False, header=True)
+
+    def get_average_pident(self) -> None:
+        df = pd.read_csv(self.tax_file, sep="\t")
+        def calculate_average(pidents):
+            entries = pidents.split(" | ")
+            pidents_values = [float(entry.split("|")[1]) for entry in entries if "|" in entry]
+            return round(np.mean(pidents_values), 1) if pidents else np.nan
+        df['Average_pident'] = df['Protein-IDs'].apply(calculate_average)
         df.to_csv(self.tax_file, sep="\t", index=False, header=True)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     Tool to analyze endogenous elements (EEs) based on similarity search
     and junctions of genomic regions.
     """,
-    version="1.0.0",
+    version="1.1.0",
     authors="Filipe Dezordi and Yago Dias",
     authors_emails='zimmer.filipe@gmail.com" and yag.dias@gmail',
     classifiers=[


### PR DESCRIPTION
# Fixing pandas future warnings

### The first warning points to the use of `inplace=True`
![pr1](https://github.com/user-attachments/assets/1207015a-9cae-4d40-873b-70222709c476)

So I used the logic suggested in the warning:
`df_blast_tax_info["Family"] = df_blast_tax_info["Family"].fillna("Unknown")`
`df_blast_tax_info["Genus"] = df_blast_tax_info["Genus"].fillna("Unknown")`

And tested if the code would still work, removing from the meta file the Caulimoviridae family:
before:
![pr2](https://github.com/user-attachments/assets/52ab03cf-bdf3-4bac-8ed6-9747bb3e8d64)
after:
![pr3](https://github.com/user-attachments/assets/9aaa5af7-f37c-4450-98e0-a3c461b03fda)

### The second warning shows incompatibility when assigning sense for the elements
![pr5](https://github.com/user-attachments/assets/a693f4dc-87e1-4526-901e-d66009363b7f)

So I converted the `sense` column with: `df["sense"] = df["sense"].astype(object)`


# Adding average_pident to tax file

Before the merge by bedtools I added the pident for every element at the `GetAnnotBed` class

For calculating and creating the column with average pident I added a new function at the `TagElements` class, maybe we could change the name of the class

example of new column:
```
Element-ID,Sense,Protein-IDs,Protein-Products,Molecule_type,Family,Genus,Species,Host,Overlaped_Element_ID,tag,Average_pident
ctg_1913:102788-103126,neg,YP_004581513.1|35.2,RNaseH/reverse transcriptase,dsDNA-RT,Caulimoviridae,Badnavirus,Sweet potato pakakuy virus,Ipomoea batatas,ctg_1913:102863-103126,ctg_1913:103146-104096,overlaped,35.2
ctg_1913:103371-103937,neg,YP_006273075.1|26.667,polyprotein,dsDNA-RT,Caulimoviridae,Badnavirus,Fig badnavirus 1,Ficus,ctg_1913:103146-104096,ctg_1913:103801-103983,overlaped,26.7
ctg_1913:86707-87048,pos,YP_006273075.1|31.579,polyprotein,dsDNA-RT,Caulimoviridae,Badnavirus,Fig badnavirus 1,Ficus,ctg_1913:86485-87463,ctg_1913:86572-87630,ctg_1913:87122-87454,overlaped,31.6
ctg_1913:1754-2686,neg,YP_006732334.1|30.573,polyprotein,dsDNA-RT,Caulimoviridae,Caulimovirus,Dahlia mosaic virus,Dahlia pinnata,ctg_1913:1448-3157,ctg_1913:1547-2743,overlaped,30.6
ctg_1913:40858-41889,neg,YP_006732334.1|31.322,polyprotein,dsDNA-RT,Caulimoviridae,Caulimovirus,Dahlia mosaic virus,Dahlia pinnata,ctg_1913:40573-42000,ctg_1913:40651-41847,overlaped,31.3
ctg_1913:102930-104099,neg,NP_659397.1|23.383 | NP_619548.1|24.432 | YP_006907834.1|24.138,polyprotein AND hypothetical protein,dsDNA-RT,Caulimoviridae,Caulimovirus,Horseradish latent virus AND Figwort mosaic virus AND Mirabilis mosaic virus,Armoracia rusticana,ctg_1913:102863-103126,ctg_1913:103146-104096,ctg_1913:103801-103983,overlaped,24.0
```