### PR TITLE
fix: include reference, fix logger name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,15 @@ pip install .
 ```bash
 eefinder --version
 
-#eefinder, version 1.0.0
+#eefinder, version 1.1.1
 ```
 
 For more information, check [EEfinder Wiki here](https://github.com/WallauBioinfo/EEfinder/wiki)
+
+#### Cite us
+
+If you use EEfinder in your research, please cite https://www.sciencedirect.com/science/article/pii/S2001037024003325:
+
+```
+Dias, Y. J. M., Dezordi, F. Z., & Wallau, G. L. (2024). EEFinder: A general-purpose tool for identification of bacterial and viral endogenized elements in eukaryotic genomes. Computational and Structural Biotechnology Journal. https://doi.org/10.1016/j.csbj.2024.10.012
+```

--- a/eefinder/log.py
+++ b/eefinder/log.py
@@ -1,4 +1,4 @@
 import logging
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("")
+logger = logging.getLogger("eefinder")

--- a/eefinder/run_message.py
+++ b/eefinder/run_message.py
@@ -14,8 +14,10 @@ def print_paper_info(version: str):
 
 
 def print_end_info():
-    click.secho(f"Thank You for use EEfinder!", fg="green")
-    click.secho(f"Please Cite: the study is being prepared for publication.", fg="green")
+    click.secho("Thank You for use EEfinder!", fg="green")
+    click.secho("Please Cite: Dias, Y. J. M., Dezordi, F. Z., & Wallau, G. L. (2024). "
+                +"EEFinder: A general-purpose tool for identification of bacterial and viral endogenized elements in eukaryotic genomes. "
+                +"Computational and Structural Biotechnology Journal. https://doi.org/10.1016/j.csbj.2024.10.012", fg="green")
     print("\n")
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     Tool to analyze endogenous elements (EEs) based on similarity search
     and junctions of genomic regions.
     """,
-    version="1.1.0",
+    version="1.1.1",
     authors="Filipe Dezordi and Yago Dias",
     authors_emails='zimmer.filipe@gmail.com" and yag.dias@gmail',
     classifiers=[


### PR DESCRIPTION
Include the article reference, i also adjusted the logger name to put in the log info the eefinder name instead the default `root`:

![Screenshot 2024-10-19 at 08 51 54](https://github.com/user-attachments/assets/eb597575-23b8-4d68-bb93-6a5cc6871b71)
